### PR TITLE
test(ci): block broken plugin changes before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Bun ${{ matrix.bun-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bun-version: ["1.1.34", "latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+      - run: bun install --frozen-lockfile
+      - run: bun run check
+      - name: Test with an isolated home directory
+        env:
+          HOME: ${{ runner.temp }}/test-home
+        run: |
+          mkdir -p "$HOME"
+          bun test

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -1,0 +1,38 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const INTERNAL_COMMANDS = new Set(["once", "dry-run"]);
+
+function documentedCliCommands(source: string): string[] {
+  const usage = source.match(/"usage: cli\.ts ([^"]+)"/)?.[1];
+  assert.ok(usage, "CLI usage string not found");
+  return usage.split("|").map((entry) => entry.trim().split(/\s+/)[0]!);
+}
+
+function manifestCliCommands(source: string): string[] {
+  const commands: string[] = [];
+  const actionBlocks = source
+    .split(/\n(?=\[\[)/)
+    .filter((block) => block.startsWith("[[actions]]"));
+  for (const block of actionBlocks) {
+    const encodedArgs = block.match(/^command = \[(.*)\]$/m)?.[1];
+    assert.ok(encodedArgs, "plugin action command not found");
+    const args = JSON.parse(`[${encodedArgs}]`) as string[];
+    assert.deepEqual(args.slice(0, 3), ["sh", "src/run-bun.sh", "src/cli.ts"]);
+    assert.ok(args[3], "plugin action CLI command not found");
+    commands.push(args[3]);
+  }
+  return commands;
+}
+
+test("documented CLI actions are registered in the Herdr manifest", async () => {
+  const [cli, manifest] = await Promise.all([
+    readFile(new URL("../src/cli.ts", import.meta.url), "utf8"),
+    readFile(new URL("../herdr-plugin.toml", import.meta.url), "utf8"),
+  ]);
+  const documented = documentedCliCommands(cli).filter(
+    (command) => !INTERNAL_COMMANDS.has(command),
+  );
+  assert.deepEqual(manifestCliCommands(manifest).sort(), documented.sort());
+});

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -142,6 +142,66 @@ test("namer sends one bounded completion and validates model output", async () =
   await assert.rejects(invalid.suggest(context), /invalid model tab label/);
 });
 
+test("provider transport enforces the output-token ceiling without external network", async () => {
+  let requestBody: Record<string, unknown> | undefined;
+  const responseText = '{"tab":"Bound Provider Output","reason":"transport contract"}';
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      requestBody = (await request.json()) as Record<string, unknown>;
+      if (requestBody.stream === true) {
+        const chunk = {
+          id: "chatcmpl-test",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "test-model",
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant", content: responseText },
+              finish_reason: "stop",
+            },
+          ],
+        };
+        return new Response(
+          `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`,
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return Response.json({
+        id: "chatcmpl-test",
+        object: "chat.completion",
+        created: 0,
+        model: "test-model",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: responseText },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      });
+    },
+  });
+  try {
+    const namer = new AiSdkNamer({
+      SMART_RENAME_PROVIDER: "test-provider",
+      SMART_RENAME_BASE_URL: `http://127.0.0.1:${server.port}/v1`,
+      SMART_RENAME_MODEL: "test-model",
+      SMART_RENAME_API_KEY: "test-key",
+      SMART_RENAME_TIMEOUT_MS: "5000",
+    });
+    assert.deepEqual(await namer.suggest(context), {
+      tab: "Bound Provider Output",
+      reason: "transport contract",
+    });
+    assert.equal(requestBody?.max_tokens, 32_768);
+  } finally {
+    server.stop(true);
+  }
+});
+
 test("namer reloads provider.env and naming-prompt.md, then redacts failures", async () => {
   const fixture = await tempConfig();
   const promptFile = path.join(fixture.root, "naming-prompt.md");


### PR DESCRIPTION
### What

Adds required pull-request checks for the supported Bun baseline and current Bun, with tests running against an isolated home directory.

### Quality gates

- Verify the frozen lockfile, TypeScript, and full test suite on Bun 1.1.34 and latest.
- Keep documented CLI commands synchronized with Herdr manifest actions.
- Exercise the provider through a local HTTP/SSE boundary and enforce the 32,768 output-token ceiling without external API calls.

These gates reproduce the regressions found in PR #2 before code reaches `main`.
