### PR TITLE
fix: use max_completion_tokens for Luna

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -262,6 +262,17 @@ async function completeWithAiSdk(request: CompletionRequest): Promise<string> {
     name: request.config.provider,
     baseURL: request.config.baseURL,
     apiKey: request.config.apiKey,
+    ...(request.config.provider === "openai"
+      ? {
+          transformRequestBody: (body: Record<string, unknown>) => {
+            const { max_tokens: maxCompletionTokens, ...rest } = body;
+            return {
+              ...rest,
+              max_completion_tokens: maxCompletionTokens,
+            };
+          },
+        }
+      : {}),
   });
   const result = await generateText({
     model: provider(request.config.model),

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -257,6 +257,14 @@ export interface CompletionRequest {
 
 type Complete = (request: CompletionRequest) => Promise<string>;
 
+export function transformOpenAiRequestBody(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const { max_tokens: maxCompletionTokens, ...rest } = body;
+  if (maxCompletionTokens === null || maxCompletionTokens === undefined) return rest;
+  return { ...rest, max_completion_tokens: maxCompletionTokens };
+}
+
 async function completeWithAiSdk(request: CompletionRequest): Promise<string> {
   const provider = createOpenAICompatible({
     name: request.config.provider,
@@ -264,13 +272,7 @@ async function completeWithAiSdk(request: CompletionRequest): Promise<string> {
     apiKey: request.config.apiKey,
     ...(request.config.provider === "openai"
       ? {
-          transformRequestBody: (body: Record<string, unknown>) => {
-            const { max_tokens: maxCompletionTokens, ...rest } = body;
-            return {
-              ...rest,
-              max_completion_tokens: maxCompletionTokens,
-            };
-          },
+          transformRequestBody: transformOpenAiRequestBody,
         }
       : {}),
   });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -260,9 +260,10 @@ type Complete = (request: CompletionRequest) => Promise<string>;
 export function transformOpenAiRequestBody(
   body: Record<string, unknown>,
 ): Record<string, unknown> {
-  const { max_tokens: maxCompletionTokens, ...rest } = body;
-  if (maxCompletionTokens === null || maxCompletionTokens === undefined) return rest;
-  return { ...rest, max_completion_tokens: maxCompletionTokens };
+  const { max_tokens, ...rest } = body;
+  return max_tokens == null
+    ? rest
+    : { ...rest, max_completion_tokens: max_tokens };
 }
 
 async function completeWithAiSdk(request: CompletionRequest): Promise<string> {

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -216,6 +216,14 @@ test("provider transport uses the provider-compatible output-token parameter", a
 
 test("OpenAI request transform preserves native completion-token values", () => {
   assert.deepEqual(
+    transformOpenAiRequestBody({ model: "m", max_tokens: 5 }),
+    { model: "m", max_completion_tokens: 5 },
+  );
+  assert.deepEqual(
+    transformOpenAiRequestBody({ max_tokens: 5, max_completion_tokens: 7 }),
+    { max_completion_tokens: 5 },
+  );
+  assert.deepEqual(
     transformOpenAiRequestBody({ max_completion_tokens: 123 }),
     { max_completion_tokens: 123 },
   );

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -142,7 +142,7 @@ test("namer sends one bounded completion and validates model output", async () =
   await assert.rejects(invalid.suggest(context), /invalid model tab label/);
 });
 
-test("provider transport enforces the output-token ceiling without external network", async () => {
+test("provider transport uses the provider-compatible output-token parameter", async () => {
   let requestBody: Record<string, unknown> | undefined;
   const responseText = '{"tab":"Bound Provider Output","reason":"transport contract"}';
   const server = Bun.serve({
@@ -197,6 +197,17 @@ test("provider transport enforces the output-token ceiling without external netw
       reason: "transport contract",
     });
     assert.equal(requestBody?.max_tokens, 32_768);
+
+    const openaiNamer = new AiSdkNamer({
+      SMART_RENAME_PROVIDER: "openai",
+      SMART_RENAME_BASE_URL: `http://127.0.0.1:${server.port}/v1`,
+      SMART_RENAME_MODEL: "gpt-5.6-luna",
+      SMART_RENAME_API_KEY: "test-key",
+      SMART_RENAME_TIMEOUT_MS: "5000",
+    });
+    await openaiNamer.suggest(context);
+    assert.equal(requestBody?.max_completion_tokens, 32_768);
+    assert.equal(requestBody?.max_tokens, undefined);
   } finally {
     server.stop(true);
   }

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -18,6 +18,7 @@ import {
   AiSdkNamer,
   loadProviderConfig,
   type CompletionRequest,
+  transformOpenAiRequestBody,
 } from "../src/provider.ts";
 import { type NamingContext } from "../src/domain.ts";
 
@@ -211,6 +212,17 @@ test("provider transport uses the provider-compatible output-token parameter", a
   } finally {
     server.stop(true);
   }
+});
+
+test("OpenAI request transform preserves native completion-token values", () => {
+  assert.deepEqual(
+    transformOpenAiRequestBody({ max_completion_tokens: 123 }),
+    { max_completion_tokens: 123 },
+  );
+  assert.deepEqual(
+    transformOpenAiRequestBody({ max_tokens: null, max_completion_tokens: 123 }),
+    { max_completion_tokens: 123 },
+  );
 });
 
 test("namer reloads provider.env and naming-prompt.md, then redacts failures", async () => {


### PR DESCRIPTION
Luna rejects `max_tokens`. Send `max_completion_tokens` for OpenAI; keep other providers unchanged.

Tested against Luna. Tests and typecheck pass.