### PR TITLE
feat: add native Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,15 @@ jobs:
         run: |
           mkdir -p "$HOME"
           bun test
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run check
+      - run: bun test

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ OPENAI_API_KEY=...
 
 Without a key, deterministic names still work.
 
+### Windows
+
+Herdr's Windows preview is supported with Bun available on `PATH`. The plugin
+uses direct Bun commands instead of a Unix shell launcher, and inspects worker
+processes through PowerShell.
+
 ## Keybindings
 
 ```toml

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -3,7 +3,7 @@ name = "Smart Rename"
 version = "0.1.1"
 min_herdr_version = "0.7.0"
 description = "Context-aware names for Herdr workspaces and task tabs."
-platforms = ["linux", "macos"]
+platforms = ["linux", "macos", "windows"]
 
 [[build]]
 command = ["bun", "install", "--production", "--frozen-lockfile"]
@@ -13,81 +13,81 @@ id = "start"
 title = "Smart Rename: start"
 description = "Start the detached Smart Rename worker."
 contexts = ["global", "workspace"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "start"]
+command = ["bun", "src/cli.ts", "start"]
 
 [[actions]]
 id = "stop"
 title = "Smart Rename: stop"
 description = "Stop the Smart Rename worker."
 contexts = ["global", "workspace"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "stop"]
+command = ["bun", "src/cli.ts", "stop"]
 
 [[actions]]
 id = "status"
 title = "Smart Rename: status"
 description = "Report worker status."
 contexts = ["global", "workspace"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "status"]
+command = ["bun", "src/cli.ts", "status"]
 
 [[actions]]
 id = "configure-ai"
 title = "Smart Rename: configure AI"
 description = "Open the private AI provider configuration."
 contexts = ["global", "workspace", "tab", "pane"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "configure-ai"]
+command = ["bun", "src/cli.ts", "configure-ai"]
 
 [[actions]]
 id = "configure-prompt"
 title = "Smart Rename: configure prompt"
 description = "Open the private naming prompt."
 contexts = ["global", "workspace", "tab", "pane"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "configure-prompt"]
+command = ["bun", "src/cli.ts", "configure-prompt"]
 
 [[actions]]
 id = "check-ai"
 title = "Smart Rename: check AI config"
 description = "Validate the provider and naming prompt without making a request."
 contexts = ["global", "workspace", "tab", "pane"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "check-ai"]
+command = ["bun", "src/cli.ts", "check-ai"]
 
 [[actions]]
 id = "rename-now"
 title = "Smart Rename: current tab"
 description = "Reclaim and rename the current tab now."
 contexts = ["workspace", "tab", "pane"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "rename-now"]
+command = ["bun", "src/cli.ts", "rename-now"]
 
 [[actions]]
 id = "rename-all"
 title = "Smart Rename: all tabs"
 description = "Reclaim and rename every tab sequentially."
 contexts = ["global", "workspace", "tab", "pane"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "all"]
+command = ["bun", "src/cli.ts", "all"]
 
 [[actions]]
 id = "reset-tab"
 title = "Smart Rename: reset tab"
 description = "Clear the current tab's manual lock and evaluate it."
 contexts = ["tab", "pane"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "reset-tab"]
+command = ["bun", "src/cli.ts", "reset-tab"]
 
 [[actions]]
 id = "reset-workspace"
 title = "Smart Rename: reset workspace"
 description = "Clear the current workspace's manual lock and evaluate it."
 contexts = ["workspace", "tab", "pane"]
-command = ["sh", "src/run-bun.sh", "src/cli.ts", "reset-workspace"]
+command = ["bun", "src/cli.ts", "reset-workspace"]
 
 [[panes]]
 id = "provider-config"
 title = "Smart Rename AI"
 description = "Edit the private OpenAI-compatible provider configuration."
 placement = "overlay"
-command = ["sh", "src/run-bun.sh", "src/configure.ts"]
+command = ["bun", "src/configure.ts"]
 
 [[panes]]
 id = "prompt-config"
 title = "Smart Rename Prompt"
 description = "Edit the private naming prompt."
 placement = "overlay"
-command = ["sh", "src/run-bun.sh", "src/configure.ts", "prompt"]
+command = ["bun", "src/configure.ts", "prompt"]

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -152,7 +152,7 @@ async function commandForPid(pid: number): Promise<string> {
         "-Command",
         `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; if ($p) { $p.CommandLine }`,
       ],
-      { stdout: "pipe", stderr: "ignore" },
+      { stdout: "pipe", stderr: "ignore", windowsHide: true },
     );
     const [command, exitCode] = await Promise.all([
       new Response(child.stdout).text(),
@@ -225,8 +225,9 @@ async function staleLock(lockFile: string, staleMs: number): Promise<boolean> {
   let age = Infinity;
   try {
     age = Date.now() - (await stat(lockFile)).mtimeMs;
-  } catch {
-    return true;
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return false;
+    throw error;
   }
   try {
     const owner = LockOwnerSchema.parse(JSON.parse(await readFile(lockFile, "utf8")));

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -143,13 +143,31 @@ export function pidAlive(
 }
 
 async function commandForPid(pid: number): Promise<string> {
-  const process = Bun.spawn(["ps", "-p", String(pid), "-o", "command="], {
+  if (process.platform === "win32") {
+    const child = Bun.spawn(
+      [
+        "powershell.exe",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; if ($p) { $p.CommandLine }`,
+      ],
+      { stdout: "pipe", stderr: "ignore" },
+    );
+    const [command, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      child.exited,
+    ]);
+    if (exitCode !== 0) throw new Error(`PowerShell exited ${exitCode}`);
+    return command.trim();
+  }
+  const psProcess = Bun.spawn(["ps", "-p", String(pid), "-o", "command="], {
     stdout: "pipe",
     stderr: "ignore",
   });
   const [command, exitCode] = await Promise.all([
-    new Response(process.stdout).text(),
-    process.exited,
+    new Response(psProcess.stdout).text(),
+    psProcess.exited,
   ]);
   if (exitCode !== 0) throw new Error(`ps exited ${exitCode}`);
   return command.trim();

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -19,9 +19,9 @@ function manifestCliCommands(source: string): string[] {
     const encodedArgs = block.match(/^command = \[(.*)\]$/m)?.[1];
     assert.ok(encodedArgs, "plugin action command not found");
     const args = JSON.parse(`[${encodedArgs}]`) as string[];
-    assert.deepEqual(args.slice(0, 3), ["sh", "src/run-bun.sh", "src/cli.ts"]);
-    assert.ok(args[3], "plugin action CLI command not found");
-    commands.push(args[3]);
+    assert.deepEqual(args.slice(0, 2), ["bun", "src/cli.ts"]);
+    assert.ok(args[2], "plugin action CLI command not found");
+    commands.push(args[2]);
   }
   return commands;
 }

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -93,9 +93,11 @@ test("private provider and prompt config enforce templates, permissions, and bou
   try {
     const file = await ensureProviderFile(fixture.env);
     const prompt = await ensureNamingPromptFile(fixture.env);
-    assert.equal((await stat(fixture.root)).mode & 0o777, 0o700);
-    assert.equal((await stat(file)).mode & 0o777, 0o600);
-    assert.equal((await stat(prompt)).mode & 0o777, 0o600);
+    if (process.platform !== "win32") {
+      assert.equal((await stat(fixture.root)).mode & 0o777, 0o700);
+      assert.equal((await stat(file)).mode & 0o777, 0o600);
+      assert.equal((await stat(prompt)).mode & 0o777, 0o600);
+    }
     assert.match(await readFile(file, "utf8"), /SMART_RENAME_MODEL=gpt-5\.6-luna/);
     assert.match(await readFile(prompt, "utf8"), /^# Naming policy/);
     await assert.rejects(loadProviderConfig(fixture.env), /AI key missing.*provider\.env/i);
@@ -260,9 +262,12 @@ test("manifest uses portable Bun runtime without Pi model coupling", async () =>
   );
   assert.match(
     manifest,
-    /command = \["sh", "src\/run-bun\.sh", "src\/cli\.ts", "start"\]/,
+    /platforms = \["linux", "macos", "windows"\]/,
   );
-  assert.doesNotMatch(manifest, /command = \["bun", "src\//);
+  assert.match(
+    manifest,
+    /command = \["bun", "src\/cli\.ts", "start"\]/,
+  );
   assert.match(manifest, /id = "provider-config"[\s\S]*placement = "overlay"/);
   assert.match(manifest, /id = "prompt-config"[\s\S]*placement = "overlay"/);
 

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -146,17 +146,22 @@ test("locks recover dead owners and workers require exact Bun scripts", async ()
   }
 });
 
-test("worker inspection uses the native process lookup on Windows", async () => {
-  if (process.platform !== "win32") return;
-  const dir = await mkdtemp(path.join(os.tmpdir(), "tab-smart-rename-process-"));
-  const pidFile = path.join(dir, "worker.json");
-  try {
-    await writeFile(
-      pidFile,
-      `${JSON.stringify({ pid: process.pid, script: "bun", startedAt: "now" })}\n`,
-    );
-    assert.equal((await workerInfo(pidFile, "bun"))?.pid, process.pid);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
+test(
+  "worker inspection uses the native process lookup on Windows",
+  async () => {
+    if (process.platform !== "win32") return;
+    const dir = await mkdtemp(path.join(os.tmpdir(), "tab-smart-rename-process-"));
+    const pidFile = path.join(dir, "worker.json");
+    try {
+      await writeFile(
+        pidFile,
+        `${JSON.stringify({ pid: process.pid, script: "bun", startedAt: "now" })}\n`,
+      );
+      assert.equal((await workerInfo(pidFile, "bun"))?.pid, process.pid);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+  // Hosted Windows cold-starts Windows PowerShell beyond Bun's 5s default.
+  { timeout: 15_000 },
+);

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -75,6 +75,7 @@ test("CLI dispatch routes actions without executing on import", async () => {
 });
 
 test("Bun launcher survives Herdr's minimal server PATH", async () => {
+  if (process.platform === "win32") return;
   const home = await mkdtemp(path.join(os.tmpdir(), "tab-smart-rename-bun-"));
   const bunDir = path.join(home, ".bun", "bin");
   const fakeBun = path.join(bunDir, "bun");
@@ -140,6 +141,21 @@ test("locks recover dead owners and workers require exact Bun scripts", async ()
       await workerInfo(pidFile, "/other/src/worker.ts", dependencies),
       null,
     );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("worker inspection uses the native process lookup on Windows", async () => {
+  if (process.platform !== "win32") return;
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tab-smart-rename-process-"));
+  const pidFile = path.join(dir, "worker.json");
+  try {
+    await writeFile(
+      pidFile,
+      `${JSON.stringify({ pid: process.pid, script: "bun", startedAt: "now" })}\n`,
+    );
+    assert.equal((await workerInfo(pidFile, "bun"))?.pid, process.pid);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What changed\n\n- declare Windows support in the Herdr manifest\n- replace Unix shell launchers with direct Bun commands\n- inspect worker commands with PowerShell on Windows\n- guard Unix-only permission and launcher assertions\n- add a Windows CI job and a native process inspection test\n\n## Validation\n\n- un run check\n- un test (26 passing on Windows)\n\nThis PR intentionally does not include the OpenAI token-parameter fix from upstream PR #4.