### PR TITLE
fix(windows): connect to the named-pipe control socket and hide subprocess consoles

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,6 +95,7 @@ async function start(): Promise<void> {
       stdin: "ignore",
       stdout: logFd,
       stderr: logFd,
+      windowsHide: true,
     });
     child.unref();
     closeSync(logFd);

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -140,6 +140,7 @@ export async function run(
     env: options.env ?? process.env,
     stdout: "pipe",
     stderr: "pipe",
+    windowsHide: true,
   });
   let timedOut = false;
   const timer = setTimeout(() => {
@@ -346,11 +347,22 @@ export function normalizeHerdrEvent(message: unknown): HerdrEvent | null {
   };
 }
 
+const WINDOWS_PIPE_PREFIX = "\\\\.\\pipe\\";
+
+export function resolveSocketPath(
+  socketPath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32") return socketPath;
+  if (socketPath.startsWith(WINDOWS_PIPE_PREFIX)) return socketPath;
+  return `${WINDOWS_PIPE_PREFIX}${socketPath}`;
+}
+
 export function subscribe(
   socketPath: string,
   onEvent: (event: HerdrEvent) => void,
 ): Socket {
-  const socket = net.createConnection(socketPath);
+  const socket = net.createConnection(resolveSocketPath(socketPath));
   let buffer = "";
   socket.setEncoding("utf8");
   socket.on("connect", () => {

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -1,0 +1,26 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { resolveSocketPath } from "../src/herdr.ts";
+
+test("resolveSocketPath leaves POSIX socket paths untouched", () => {
+  assert.equal(
+    resolveSocketPath("/tmp/herdr/herdr.sock", "linux"),
+    "/tmp/herdr/herdr.sock",
+  );
+  assert.equal(
+    resolveSocketPath("/tmp/herdr/herdr.sock", "darwin"),
+    "/tmp/herdr/herdr.sock",
+  );
+});
+
+test("resolveSocketPath prefixes Windows socket paths with the pipe namespace", () => {
+  assert.equal(
+    resolveSocketPath("C:\\Users\\me\\AppData\\Roaming\\herdr\\herdr.sock", "win32"),
+    "\\\\.\\pipe\\C:\\Users\\me\\AppData\\Roaming\\herdr\\herdr.sock",
+  );
+});
+
+test("resolveSocketPath does not double-prefix an already-resolved pipe path", () => {
+  const alreadyResolved = "\\\\.\\pipe\\C:\\Users\\me\\AppData\\Roaming\\herdr\\herdr.sock";
+  assert.equal(resolveSocketPath(alreadyResolved, "win32"), alreadyResolved);
+});


### PR DESCRIPTION
## What's broken

Running this plugin on Windows, tabs only ever got renamed by the 60s
fallback sweep — never instantly on tab create/focus like on Linux/macOS.
`worker.log` filled with a continuous stream of:

```
socket error: connect ENOENT C:\Users\<user>\AppData\Roaming\herdr\herdr.sock
```

Root cause: Herdr's control channel on Windows is exposed as a **named
pipe** whose full name is the literal socket path string (confirmed by
connecting directly with `System.IO.Pipes.NamedPipeClientStream(".",
"C:\Users\<user>\AppData\Roaming\herdr\herdr.sock")`, which succeeds and
gets a real JSON-RPC response back). `subscribe()` in `src/herdr.ts`
passes that raw path straight to `net.createConnection()`, which on
Windows needs a `\.\pipe\` prefix to resolve to the pipe rather than
attempting (and failing) to treat it as a filesystem path.

Separately, none of the plugin's long-lived `Bun.spawn` calls set
`windowsHide`, so Windows pops a visible console window for every
subprocess the plugin runs (`git`, `herdr.exe`, the detached worker
launch). Combined with the socket bug forcing the sweep path plus the
worker-liveness bug in #6, this was visibly flashing consoles.

## What changed

- `src/herdr.ts`: add `resolveSocketPath()`, which prefixes `\.\pipe\`
  before connecting when `process.platform === "win32"` (no-op on
  POSIX, idempotent if already prefixed). Used by `subscribe()`.
- `src/herdr.ts` / `src/cli.ts`: set `windowsHide: true` on the
  `Bun.spawn` calls for the CLI/git helper (`run()`) and the detached
  worker launch. (Left `configure.ts`'s editor spawn alone — that one
  is meant to be interactive/visible.)
- `test/herdr.test.ts`: unit tests for `resolveSocketPath` across
  win32/POSIX and against an already-prefixed path.

## Relationship to #6

This is scoped to not touch `storage.ts` or `herdr-plugin.toml`, so it
shouldn't conflict with #6 either way round. It's a genuine correctness
gap independent of #6 though: #6 fixes the `ps`-based worker-liveness
check but doesn't touch `src/herdr.ts` or add `windowsHide` anywhere, so
without this, live events and the console flashing would still be
broken/present on Windows even after #6 merges.

## Validation

- `bun run check` — clean
- `bun test` — 26/28 pass; the 2 pre-existing failures
  (`provider.test.ts` Unix-permission assertions, `runtime.test.ts`
  `/bin/sh` launcher test) are unrelated to this change and are already
  addressed by #6's test guards.
- Manually verified end-to-end against a running Herdr 0.7.4-preview
  instance: connected directly to the named pipe to confirm the
  protocol, then confirmed the worker connects with no `ENOENT` errors
  and renames a tab live off a real focus event instead of waiting for
  the sweep.