### PR TITLE
feat: use OMP subscriptions for Smart Rename

### DIFF
--- a/provider.env.example
+++ b/provider.env.example
@@ -13,3 +13,8 @@ SMART_RENAME_TIMEOUT_MS=45000
 
 # Optional custom prompt. Relative paths resolve from the plugin config directory:
 # SMART_RENAME_PROMPT_PATH=naming-prompt.md
+
+# Subscription-backed OMP CLI (no base URL or API key required)
+# SMART_RENAME_PROVIDER=omp
+# SMART_RENAME_MODEL=github-copilot/gpt-5.6-luna
+# SMART_RENAME_REASONING_EFFORT=low

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -20,21 +20,46 @@ const BUNDLED_NAMING_PROMPT = fileURLToPath(
 export const PROVIDER_ENV_NAME = "provider.env";
 export const NAMING_PROMPT_NAME = "naming-prompt.md";
 
-const ProviderConfigSchema = z.object({
-  provider: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/),
-  baseURL: z
-    .url()
-    .refine((value) => {
-      const url = new URL(value);
-      return ["http:", "https:"].includes(url.protocol) && !url.username && !url.password;
-    })
-    .transform((value) => value.replace(/\/$/, "")),
-  model: z.string().min(1).refine((value) => !/[\r\n]/.test(value)),
-  timeoutMs: z.number().int().min(1_000).max(300_000),
-  reasoningEffort: z.enum(["low", "medium", "high"]).optional(),
-  promptPath: z.string().min(1).optional(),
-  apiKey: z.string().min(1),
-});
+const HttpBaseUrlSchema = z
+  .string()
+  .url()
+  .refine((value) => {
+    const url = new URL(value);
+    return ["http:", "https:"].includes(url.protocol) && !url.username && !url.password;
+  });
+
+const ProviderConfigSchema = z
+  .object({
+    provider: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/),
+    baseURL: z.string().optional(),
+    model: z.string().min(1).refine((value) => !/[\r\n]/.test(value)),
+    timeoutMs: z.number().int().min(1_000).max(300_000),
+    reasoningEffort: z.enum(["low", "medium", "high"]).optional(),
+    promptPath: z.string().min(1).optional(),
+    apiKey: z.string().min(1).optional(),
+  })
+  .superRefine((config, context) => {
+    if (config.provider === "omp") return;
+    if (!config.baseURL || !HttpBaseUrlSchema.safeParse(config.baseURL).success) {
+      context.addIssue({
+        code: "custom",
+        path: ["baseURL"],
+        message: "SMART_RENAME_BASE_URL must be an HTTP(S) URL without credentials",
+      });
+    }
+    if (!config.apiKey) {
+      context.addIssue({
+        code: "custom",
+        path: ["apiKey"],
+        message: "AI key missing",
+      });
+    }
+  })
+  .transform((config) =>
+    config.baseURL
+      ? { ...config, baseURL: config.baseURL.replace(/\/$/, "") }
+      : config,
+  );
 
 const ModelOutputSchema = z.object({
   tab: z.string().nullable(),
@@ -184,18 +209,25 @@ export async function loadProviderConfig(
     (provider === defaults.SMART_RENAME_PROVIDER
       ? defaults.SMART_RENAME_REASONING_EFFORT
       : "");
+  const baseURL = pick(
+    env,
+    fileEnv,
+    provider === "omp" ? {} : defaults,
+    "SMART_RENAME_BASE_URL",
+  );
+  const apiKey = providerApiKey(provider, env, fileEnv);
   const configuredPrompt =
     env.SMART_RENAME_PROMPT_PATH || fileEnv.SMART_RENAME_PROMPT_PATH;
   const input = {
     provider,
-    baseURL: pick(env, fileEnv, defaults, "SMART_RENAME_BASE_URL"),
+    ...(baseURL ? { baseURL } : {}),
     model: pick(env, fileEnv, defaults, "SMART_RENAME_MODEL"),
     timeoutMs: Number(pick(env, fileEnv, defaults, "SMART_RENAME_TIMEOUT_MS")),
     ...(reasoningEffort ? { reasoningEffort } : {}),
     ...(configuredPrompt
       ? { promptPath: resolvePromptPath(configuredPrompt, env) }
       : {}),
-    apiKey: providerApiKey(provider, env, fileEnv),
+    ...(apiKey ? { apiKey } : {}),
   };
   const parsed = ProviderConfigSchema.safeParse(input);
   if (!parsed.success) throw configError(parsed.error);
@@ -242,7 +274,7 @@ function parseSuggestion(text: string): NameSuggestion {
 
 function safeProviderError(error: unknown, config: ProviderConfig): string {
   let message = error instanceof Error ? error.message : String(error || "provider request failed");
-  message = message.replaceAll(config.apiKey, "[redacted]");
+  if (config.apiKey) message = message.replaceAll(config.apiKey, "[redacted]");
   return sanitizeText(message).slice(0, 400) || "provider request failed";
 }
 
@@ -252,6 +284,7 @@ export interface CompletionRequest {
   system: string;
   maxOutputTokens: 32_768;
   maxRetries: 1;
+  env: NodeJS.ProcessEnv;
   abortSignal: AbortSignal;
 }
 
@@ -267,10 +300,12 @@ export function transformOpenAiRequestBody(
 }
 
 async function completeWithAiSdk(request: CompletionRequest): Promise<string> {
+  const { baseURL, apiKey } = request.config;
+  if (!baseURL || !apiKey) throw new Error("provider configuration is incomplete");
   const provider = createOpenAICompatible({
     name: request.config.provider,
-    baseURL: request.config.baseURL,
-    apiKey: request.config.apiKey,
+    baseURL,
+    apiKey,
     ...(request.config.provider === "openai"
       ? {
           transformRequestBody: transformOpenAiRequestBody,
@@ -297,13 +332,143 @@ async function completeWithAiSdk(request: CompletionRequest): Promise<string> {
   return result.text;
 }
 
+const OMP_OUTPUT_BYTES = 2 * 1024 * 1024;
+const OMP_CLEANUP_GRACE_MS = 250;
+
+async function readBoundedOutput(
+  stream: ReadableStream<Uint8Array>,
+  label: string,
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > OMP_OUTPUT_BYTES) {
+        throw new Error(`${label} output exceeded buffer`);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function drainOmpOutput(
+  output: Promise<[string, string]>,
+  abortPromise: Promise<never>,
+): Promise<[string, string]> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("omp output drain timed out")),
+      OMP_CLEANUP_GRACE_MS,
+    );
+  });
+  try {
+    return await Promise.race([output, abortPromise, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function completeWithOmp(request: CompletionRequest): Promise<string> {
+  const args = [
+    "omp",
+    "-p",
+    "--model",
+    request.config.model,
+    "--no-session",
+    "--no-tools",
+    "--no-lsp",
+    "--no-extensions",
+    "--no-skills",
+    "--no-rules",
+  ];
+  if (request.config.reasoningEffort) {
+    args.push("--thinking", request.config.reasoningEffort);
+  }
+  const child = Bun.spawn(args, {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...request.env },
+    windowsHide: true,
+  });
+  const prompt = `${request.system}\n\nSuggest one label from this sanitized context:\n${JSON.stringify(request.context)}\n`;
+  const stdoutPromise = readBoundedOutput(child.stdout, "omp stdout");
+  const stderrPromise = readBoundedOutput(child.stderr, "omp stderr");
+  const outputPromise = Promise.all([stdoutPromise, stderrPromise]);
+  void outputPromise.catch(() => {});
+  const stdinPromise = (async () => {
+    await child.stdin.write(prompt);
+    await child.stdin.end();
+  })();
+  let rejectAbort: (reason?: unknown) => void = () => {};
+  const abortPromise = new Promise<never>((_, reject) => {
+    rejectAbort = reject;
+  });
+  const kill = () => {
+    try {
+      child.kill();
+    } catch {
+      // The process may have exited between output and cleanup.
+    }
+  };
+  const onAbort = () => {
+    kill();
+    rejectAbort(new Error("omp request aborted"));
+  };
+  request.abortSignal.addEventListener("abort", onAbort, { once: true });
+  if (request.abortSignal.aborted) onAbort();
+  try {
+    await Promise.race([stdinPromise, abortPromise]);
+    const exitCode = await Promise.race([child.exited, abortPromise]);
+    if (request.abortSignal.aborted) throw new Error("omp request aborted");
+    let output: [string, string];
+    try {
+      output = await drainOmpOutput(outputPromise, abortPromise);
+    } catch (error) {
+      if (exitCode !== 0 && !request.abortSignal.aborted) {
+        throw new Error(`omp exit ${exitCode}`);
+      }
+      throw error;
+    }
+    if (request.abortSignal.aborted) throw new Error("omp request aborted");
+    if (exitCode !== 0) {
+      throw new Error(`omp exit ${exitCode}`);
+    }
+    return output[0];
+  } catch (error) {
+    kill();
+    await Promise.race([
+      Promise.allSettled([child.exited, stdinPromise, stdoutPromise, stderrPromise]),
+      new Promise<void>((resolve) => setTimeout(resolve, OMP_CLEANUP_GRACE_MS)),
+    ]);
+    throw error;
+  } finally {
+    request.abortSignal.removeEventListener("abort", onAbort);
+  }
+}
+
+async function completeWithProvider(request: CompletionRequest): Promise<string> {
+  return request.config.provider === "omp"
+    ? completeWithOmp(request)
+    : completeWithAiSdk(request);
+}
+
 export class AiSdkNamer implements Namer {
   readonly #env: NodeJS.ProcessEnv;
   readonly #complete: Complete;
 
   constructor(
     env: NodeJS.ProcessEnv = process.env,
-    complete: Complete = completeWithAiSdk,
+    complete: Complete = completeWithProvider,
   ) {
     this.#env = env;
     this.#complete = complete;
@@ -319,6 +484,7 @@ export class AiSdkNamer implements Namer {
         system,
         maxOutputTokens: 32_768,
         maxRetries: 1,
+        env: this.#env,
         abortSignal: AbortSignal.timeout(config.timeoutMs),
       });
       return parseSuggestion(text);

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -1,6 +1,8 @@
 import { test } from "bun:test";
 import assert from "node:assert/strict";
 import {
+  chmod,
+  mkdir,
   mkdtemp,
   readFile,
   readdir,
@@ -35,6 +37,174 @@ async function tempConfig() {
     env: { HERDR_PLUGIN_CONFIG_DIR: root },
   };
 }
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function fakeOmp(root: string, behavior: string) {
+  const bin = path.join(root, "omp-bin");
+  const argsFile = path.join(root, "omp-args.txt");
+  const stdinFile = path.join(root, "omp-stdin.txt");
+  const executable = path.join(bin, "omp");
+  await mkdir(bin, { recursive: true });
+  await writeFile(
+    executable,
+    [
+      "#!/bin/sh",
+      `printf '%s\\n' "$@" > ${shellQuote(argsFile)}`,
+      `cat > ${shellQuote(stdinFile)}`,
+      behavior,
+      "",
+    ].join("\n"),
+  );
+  await chmod(executable, 0o700);
+  return { bin, argsFile, stdinFile };
+}
+test("omp provider is keyless while other providers retain validation", async () => {
+  const fixture = await tempConfig();
+  try {
+    const omp = await loadProviderConfig({
+      ...fixture.env,
+      SMART_RENAME_PROVIDER: "omp",
+      SMART_RENAME_MODEL: "local-selector",
+    });
+    assert.equal(omp.provider, "omp");
+    assert.equal(omp.model, "local-selector");
+    assert.equal(omp.baseURL, undefined);
+    assert.equal(omp.apiKey, undefined);
+
+    await assert.rejects(
+      loadProviderConfig({
+        ...fixture.env,
+        SMART_RENAME_PROVIDER: "openai",
+        SMART_RENAME_MODEL: "remote-model",
+      }),
+      /AI key missing/i,
+    );
+    await assert.rejects(
+      loadProviderConfig({
+        ...fixture.env,
+        SMART_RENAME_PROVIDER: "openai",
+        SMART_RENAME_MODEL: "remote-model",
+        SMART_RENAME_API_KEY: "configured-secret-value",
+        SMART_RENAME_BASE_URL: "not-a-url",
+      }),
+      /URL/i,
+    );
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("omp provider invokes an isolated CLI and sends the request on stdin", async () => {
+  if (process.platform === "win32") return;
+  const fixture = await tempConfig();
+  const promptFile = path.join(fixture.root, "naming-prompt.md");
+  try {
+    await writeFile(promptFile, "Test naming prompt");
+    const fake = await fakeOmp(
+      fixture.root,
+      `printf '%s\\n' '{"tab":"OMP Task Label","reason":"from omp"}'`,
+    );
+    const searchPath = `${fake.bin}${path.delimiter}${process.env.PATH || "/usr/bin:/bin"}`;
+    const namer = new AiSdkNamer({
+      ...fixture.env,
+      PATH: searchPath,
+      SMART_RENAME_PROVIDER: "omp",
+      SMART_RENAME_MODEL: "local-selector",
+      SMART_RENAME_REASONING_EFFORT: "low",
+      SMART_RENAME_PROMPT_PATH: "naming-prompt.md",
+    });
+
+    assert.deepEqual(await namer.suggest(context), {
+      tab: "OMP Task Label",
+      reason: "from omp",
+    });
+    assert.deepEqual(
+      (await readFile(fake.argsFile, "utf8")).trimEnd().split("\n"),
+      [
+        "-p",
+        "--model",
+        "local-selector",
+        "--no-session",
+        "--no-tools",
+        "--no-lsp",
+        "--no-extensions",
+        "--no-skills",
+        "--no-rules",
+        "--thinking",
+        "low",
+      ],
+    );
+    const stdin = await readFile(fake.stdinFile, "utf8");
+    assert.match(stdin, /Test naming prompt/);
+    assert.match(stdin, /Agents/);
+    assert.match(stdin, /Fix socket reconnect/);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("omp failures cancel cleanly and redact configured secrets", async () => {
+  if (process.platform === "win32") return;
+  const fixture = await tempConfig();
+  const secret = "configured-secret-value";
+  try {
+    const runFailure = async (
+      behavior: string,
+      pattern: RegExp,
+      timeoutMs = "5000",
+    ) => {
+      const startedAt = performance.now();
+      const fake = await fakeOmp(fixture.root, behavior);
+      const searchPath = `${fake.bin}${path.delimiter}${process.env.PATH || "/usr/bin:/bin"}`;
+      const namer = new AiSdkNamer({
+        ...fixture.env,
+        PATH: searchPath,
+        SMART_RENAME_PROVIDER: "omp",
+        SMART_RENAME_MODEL: "local-selector",
+        SMART_RENAME_API_KEY: secret,
+        SMART_RENAME_TIMEOUT_MS: timeoutMs,
+      });
+      await assert.rejects(namer.suggest(context), (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, pattern);
+        assert.doesNotMatch(error.message, new RegExp(secret));
+        return true;
+      });
+      return performance.now() - startedAt;
+    };
+
+    await runFailure(
+      `printf '%s\\n' '${secret} is not JSON'`,
+      /JSON|response|model/i,
+    );
+    await runFailure(
+      `printf '%s\\n' '{"tab":"bad","reason":"${secret}"}'`,
+      /invalid model tab label/i,
+    );
+    await runFailure(
+      `printf '%s\\n' '${secret} exit 7' >&2\nprintf '%s\\n' '{"tab":"Exit after trigger","reason":"valid JSON after exit trigger"}'\nexit 7`,
+      /exit 7/i,
+    );
+    const timeoutElapsedMs = await runFailure(
+      `printf '%s\\n' '${secret} timeout trigger' >&2\nsleep 2\nprintf '%s\\n' '{"tab":"Timeout after trigger","reason":"valid JSON after timeout trigger"}'`,
+      /omp request aborted/i,
+      "1000",
+    );
+    assert.ok(
+      timeoutElapsedMs < 1800,
+      `timeout fixture took ${timeoutElapsedMs.toFixed(0)}ms instead of aborting promptly`,
+    );
+    await runFailure(
+      `printf '%s\\n' '${secret} output limit trigger' >&2\ndd if=/dev/zero bs=1024 count=2048 2>/dev/null\nprintf '%s\\n' '{"tab":"Output limit after trigger","reason":"valid JSON after output limit trigger"}'`,
+      /omp stdout output exceeded buffer/i,
+    );
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
 
 test("provider config preserves defaults and process-over-file precedence", async () => {
   const fixture = await tempConfig();


### PR DESCRIPTION
## Summary

- Add `SMART_RENAME_PROVIDER=omp` for keyless OMP CLI authentication.
- Reuse the user's existing OMP model/provider credentials, including Claude and GitHub Copilot subscriptions.
- Forward `SMART_RENAME_REASONING_EFFORT` to OMP as `--thinking`.
- Keep the existing OpenAI-compatible providers unchanged.

## Runtime behavior

The OMP path invokes literal argv equivalent to:

```text
omp -p --model <selector> --no-session --no-tools --no-lsp --no-extensions --no-skills --no-rules [--thinking <level>]
```

The naming policy and sanitized context are sent through stdin. No API key is required in Smart Rename configuration. The OMP CLI must already be installed and authenticated.

## Safety and scope

- No OMP source changes.
- No new dependency.
- No auth gateway or broker setup.
- No service/orchestration or deterministic-heuristic changes.
- Output, timeout, abort, and diagnostic handling remain bounded and validated.
- OMP's ambient MCP/context configuration remains governed by OMP; this change does not claim full process isolation.

## Verification

- `bun run check`
- `bun test` — 34 passed
- `git diff --check`
- Local Herdr smoke with OMP + `github-copilot/gpt-5.6-luna` + `low`: successfully renamed a live tab.

Configuration example:

```env
SMART_RENAME_PROVIDER=omp
SMART_RENAME_MODEL=github-copilot/gpt-5.6-luna
SMART_RENAME_REASONING_EFFORT=low
```
