### PR TITLE
fix(windows): retry lock sharing violations and load keys from SMART_RENAME_ENV_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,31 @@ herdr plugin action invoke start --plugin tab-smart-rename
 OPENAI_API_KEY=...
 ```
 
+Or keep the key in an existing secrets file and point Smart Rename at it:
+
+```dotenv
+SMART_RENAME_ENV_FILE=/absolute/path/to/secrets.env
+```
+
+The external file is reloaded before each model call. Smart Rename uses only
+the key selected by `SMART_RENAME_PROVIDER`; other variables are ignored.
+
 Without a key, deterministic names still work.
 
 ### Windows
 
 Herdr's Windows preview is supported with Bun available on `PATH`. The plugin
 uses direct Bun commands instead of a Unix shell launcher, and inspects worker
-processes through PowerShell.
+processes through PowerShell. Its event subscriber maps Herdr's `.sock` pointer
+path to the native Windows named-pipe endpoint, including the `//./pipe/`
+alias. Worker lock files treat `EACCES`/`EPERM` sharing violations as
+contention instead of hard failures.
+
+Windows paths can use forward slashes in `provider.env`, for example:
+
+```dotenv
+SMART_RENAME_ENV_FILE=C:/Users/you/secrets.env
+```
 
 ## Keybindings
 
@@ -92,7 +110,7 @@ SMART_RENAME_REASONING_EFFORT=medium
 SMART_RENAME_TIMEOUT_MS=45000
 ```
 
-Use `SMART_RENAME_API_KEY` for another OpenAI-compatible provider. `OPENAI_API_KEY` and Kimi's `KIMI_API_KEY` are also supported when their provider is selected. Config reloads before every model request.
+Use `SMART_RENAME_API_KEY` for another OpenAI-compatible provider. `OPENAI_API_KEY` and Kimi's `KIMI_API_KEY` are also supported when their provider is selected. Set `SMART_RENAME_ENV_FILE` to read that selected key from another dotenv file without copying it into Herdr's config. Config reloads before every model request.
 
 ### Custom prompt
 
@@ -117,7 +135,7 @@ Set `SMART_RENAME_PROMPT_PATH` to use another file. Prompts reload per request; 
 
 Model requests contain bounded, sanitized evidence from the dominant pane. Pi panes may contribute short user-request excerpts; sibling panes contribute process summaries only. Smart Rename removes terminal formatting, common secret shapes, and the local home path before sending context.
 
-Provider keys stay in Herdr's private plugin config and never enter Smart Rename state or logs.
+Provider keys stay in Herdr's private plugin config or the explicitly selected external env file and never enter Smart Rename state or logs.
 
 ## Troubleshooting
 

--- a/provider.env.example
+++ b/provider.env.example
@@ -11,5 +11,8 @@ SMART_RENAME_TIMEOUT_MS=45000
 # Optional generic key for another OpenAI-compatible provider:
 # SMART_RENAME_API_KEY=
 
+# Optional external env file. Only the selected provider key is consumed:
+# SMART_RENAME_ENV_FILE=/absolute/path/to/secrets.env
+
 # Optional custom prompt. Relative paths resolve from the plugin config directory:
 # SMART_RENAME_PROMPT_PATH=naming-prompt.md

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -348,13 +348,19 @@ export function normalizeHerdrEvent(message: unknown): HerdrEvent | null {
 }
 
 const WINDOWS_PIPE_PREFIX = "\\\\.\\pipe\\";
+const WINDOWS_PIPE_PREFIX_FORWARD = "//./pipe/";
 
 export function resolveSocketPath(
   socketPath: string,
   platform: NodeJS.Platform = process.platform,
 ): string {
   if (platform !== "win32") return socketPath;
-  if (socketPath.startsWith(WINDOWS_PIPE_PREFIX)) return socketPath;
+  if (
+    socketPath.startsWith(WINDOWS_PIPE_PREFIX) ||
+    socketPath.startsWith(WINDOWS_PIPE_PREFIX_FORWARD)
+  ) {
+    return socketPath;
+  }
   return `${WINDOWS_PIPE_PREFIX}${socketPath}`;
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -12,6 +12,7 @@ import {
 import { sanitizeText } from "./text.ts";
 
 const PROVIDER_ENV_BYTES = 16 * 1024;
+const EXTERNAL_ENV_BYTES = 64 * 1024;
 const NAMING_PROMPT_BYTES = 32 * 1024;
 const PROVIDER_EXAMPLE_URL = new URL("../provider.env.example", import.meta.url);
 const BUNDLED_NAMING_PROMPT = fileURLToPath(
@@ -84,6 +85,27 @@ async function readProviderEnv(
   return text === null ? {} : parseEnv(text);
 }
 
+function resolveConfigPath(value: string, env: NodeJS.ProcessEnv): string {
+  if (path.isAbsolute(value)) return value;
+  return path.resolve(env.HERDR_PLUGIN_CONFIG_DIR || process.cwd(), value);
+}
+
+async function readExternalEnv(
+  processEnv: NodeJS.ProcessEnv,
+  fileEnv: Record<string, string>,
+): Promise<Record<string, string>> {
+  const configured =
+    processEnv.SMART_RENAME_ENV_FILE || fileEnv.SMART_RENAME_ENV_FILE;
+  if (!configured) return {};
+  const text = await readBoundedText(
+    resolveConfigPath(configured, processEnv),
+    "SMART_RENAME_ENV_FILE",
+    EXTERNAL_ENV_BYTES,
+    true,
+  );
+  return text === null ? {} : parseEnv(text);
+}
+
 export async function providerExampleText(): Promise<string> {
   return (
     (await readBoundedText(
@@ -109,14 +131,14 @@ function pick(
 }
 
 function resolvePromptPath(value: string, env: NodeJS.ProcessEnv): string {
-  if (path.isAbsolute(value)) return value;
-  return path.resolve(env.HERDR_PLUGIN_CONFIG_DIR || process.cwd(), value);
+  return resolveConfigPath(value, env);
 }
 
 function providerApiKey(
   provider: string,
   processEnv: NodeJS.ProcessEnv,
   fileEnv: Record<string, string>,
+  externalEnv: Record<string, string>,
 ): string {
   const providerKey =
     provider === "openai"
@@ -128,6 +150,8 @@ function providerApiKey(
     processEnv.SMART_RENAME_API_KEY ||
     fileEnv.SMART_RENAME_API_KEY ||
     (providerKey ? processEnv[providerKey] || fileEnv[providerKey] : "") ||
+    externalEnv.SMART_RENAME_API_KEY ||
+    (providerKey ? externalEnv[providerKey] : "") ||
     ""
   );
 }
@@ -164,7 +188,7 @@ function configError(error: z.ZodError): Error {
     timeoutMs: "SMART_RENAME_TIMEOUT_MS must be 1000-300000",
     reasoningEffort: "SMART_RENAME_REASONING_EFFORT must be low, medium, or high",
     promptPath: "SMART_RENAME_PROMPT_PATH is invalid",
-    apiKey: `AI key missing. Run configure-ai or set a provider key in ${PROVIDER_ENV_NAME}`,
+    apiKey: `AI key missing. Run configure-ai or set a provider key in ${PROVIDER_ENV_NAME} or SMART_RENAME_ENV_FILE`,
   };
   return new Error(messages[field ?? ""] ?? "AI provider configuration is invalid");
 }
@@ -176,6 +200,7 @@ export async function loadProviderConfig(
     readProviderEnv(PROVIDER_EXAMPLE_URL, true),
     readProviderEnv(providerEnvPath(env)),
   ]);
+  const externalEnv = await readExternalEnv(env, fileEnv);
   const provider = pick(env, fileEnv, defaults, "SMART_RENAME_PROVIDER");
   const configuredReasoning =
     env.SMART_RENAME_REASONING_EFFORT || fileEnv.SMART_RENAME_REASONING_EFFORT;
@@ -195,7 +220,7 @@ export async function loadProviderConfig(
     ...(configuredPrompt
       ? { promptPath: resolvePromptPath(configuredPrompt, env) }
       : {}),
-    apiKey: providerApiKey(provider, env, fileEnv),
+    apiKey: providerApiKey(provider, env, fileEnv, externalEnv),
   };
   const parsed = ProviderConfigSchema.safeParse(input);
   if (!parsed.success) throw configError(parsed.error);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -129,6 +129,25 @@ function errorCode(error: unknown): string | undefined {
     : undefined;
 }
 
+export async function isLockContended(
+  error: unknown,
+  lockFile: string,
+): Promise<boolean> {
+  const code = errorCode(error);
+  if (code === "EEXIST") return true;
+  if (process.platform !== "win32" || !["EACCES", "EPERM"].includes(code || "")) {
+    return false;
+  }
+  try {
+    await stat(lockFile);
+    return true;
+  } catch (probeError) {
+    // Windows can report a sharing violation after the competing owner has
+    // already released the file. Retry only for that vanished-file race.
+    return errorCode(probeError) === "ENOENT";
+  }
+}
+
 export function pidAlive(
   pid: number,
   signal: typeof process.kill = process.kill,
@@ -268,7 +287,7 @@ export async function acquireLock(
         }
       };
     } catch (error) {
-      if (errorCode(error) !== "EEXIST") throw error;
+      if (!(await isLockContended(error, lockFile))) throw error;
       if (await staleLock(lockFile, staleMs)) {
         await rm(lockFile, { force: true });
         continue;

--- a/test/herdr.test.ts
+++ b/test/herdr.test.ts
@@ -24,3 +24,8 @@ test("resolveSocketPath does not double-prefix an already-resolved pipe path", (
   const alreadyResolved = "\\\\.\\pipe\\C:\\Users\\me\\AppData\\Roaming\\herdr\\herdr.sock";
   assert.equal(resolveSocketPath(alreadyResolved, "win32"), alreadyResolved);
 });
+
+test("resolveSocketPath accepts the forward-slash Windows pipe alias", () => {
+  const forwardSlash = "//./pipe/C:/Users/me/AppData/Roaming/herdr/herdr.sock";
+  assert.equal(resolveSocketPath(forwardSlash, "win32"), forwardSlash);
+});

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -88,6 +88,40 @@ test("provider config preserves defaults and process-over-file precedence", asyn
   }
 });
 
+test("provider config reloads a selected key from an external env file", async () => {
+  const fixture = await tempConfig();
+  const secrets = path.join(fixture.root, "secrets.env");
+  try {
+    await writeFile(
+      fixture.file,
+      [
+        `SMART_RENAME_ENV_FILE=${secrets.replaceAll("\\", "/")}`,
+        "SMART_RENAME_MODEL=external-secret-model",
+      ].join("\n"),
+    );
+    await writeFile(
+      secrets,
+      "UNRELATED_SECRET=ignored\nOPENAI_API_KEY=first-external-key\n",
+    );
+    assert.equal((await loadProviderConfig(fixture.env)).apiKey, "first-external-key");
+
+    await writeFile(secrets, "OPENAI_API_KEY=second-external-key\n");
+    assert.equal((await loadProviderConfig(fixture.env)).apiKey, "second-external-key");
+
+    assert.equal(
+      (
+        await loadProviderConfig({
+          ...fixture.env,
+          OPENAI_API_KEY: "process-key",
+        })
+      ).apiKey,
+      "process-key",
+    );
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("private provider and prompt config enforce templates, permissions, and bounds", async () => {
   const fixture = await tempConfig();
   await rm(fixture.root, { recursive: true, force: true });

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { currentResultNotice, dispatch } from "../src/cli.ts";
 import { type RenameResult } from "../src/domain.ts";
-import { acquireLock, pidAlive, workerInfo } from "../src/storage.ts";
+import { acquireLock, isLockContended, pidAlive, workerInfo } from "../src/storage.ts";
 import { shouldIgnoreProgressRename } from "../src/worker.ts";
 
 test("CLI dispatch routes actions without executing on import", async () => {
@@ -105,6 +105,24 @@ test("Bun launcher survives Herdr's minimal server PATH", async () => {
     assert.equal(stdout.trim(), "fake-bun:src/cli.ts status");
   } finally {
     await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("Windows lock contention treats sharing violations as retries", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tab-smart-rename-lock-"));
+  const lock = path.join(dir, "state.lock");
+  try {
+    await writeFile(lock, '{"pid":1,"nonce":"held"}\n');
+    assert.equal(await isLockContended({ code: "EEXIST" }, lock), true);
+    assert.equal(await isLockContended({ code: "EACCES" }, lock), process.platform === "win32");
+    assert.equal(await isLockContended({ code: "EPERM" }, lock), process.platform === "win32");
+    assert.equal(
+      await isLockContended({ code: "EACCES" }, `${lock}.missing`),
+      process.platform === "win32",
+    );
+    assert.equal(await isLockContended({ code: "EIO" }, lock), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- Treat Windows `EACCES`/`EPERM` lock-file sharing violations as contention and retry, including the vanished-file race after the owner has already released.
- Add `SMART_RENAME_ENV_FILE` so the selected provider key can live in an existing secrets file instead of being copied into Herdr plugin config.
- Accept the `//./pipe/` named-pipe alias so already-resolved Windows socket paths are not double-prefixed.

These are the leftovers from the local `windows-jobengine-env` branch after #6/#8/#4 landed. Sweep batching and other house-only changes are not included.

## Test plan
- [x] `bun run check`
- [x] `bun test` (34 passing on Windows)
- [ ] Confirm `SMART_RENAME_ENV_FILE` reloads a key from an existing secrets file
- [ ] Confirm a contended Windows lock retries instead of throwing