### PR TITLE
feat(domain): support CJK / Chinese tab labels

### DIFF
--- a/docs/naming-policy.md
+++ b/docs/naming-policy.md
@@ -23,18 +23,18 @@ If no clear task exists:
 Keep `reason` short. Never expose hidden reasoning or quote sensitive context. If any label rule cannot be satisfied, abstain.
 
 ## Label rules
-
 A label must:
 
 - describe the task, not its actor or incidental tool;
-- use 2–4 words and at most 30 characters;
-- use readable Title Case and preserve acronyms;
+- match the primary language of the user requests: use concise Chinese (2–12 characters) if requests are in Chinese, or 2–4 Title Case English words if in English;
+- stay under 30 characters;
 - omit project, app, agent, model, and provider prefixes;
 - prefer concrete verbs and nouns without invented specificity.
 
 Include a project or tool name only when it is the task object and omission would change the meaning.
 
-Good: `Review Auth Changes`, `Repair Tab Ownership`, `Run Tests`, `View API Logs`.
+Good (Chinese): `修复认证问题`, `修复 MCP 故障`, `同步代码分支`, `清理系统进程`.
+Good (English): `Review Auth Changes`, `Repair Tab Ownership`, `Run Tests`, `View API Logs`.
 
 Bad: `Kimi Auth Review`, `Pi Coding Agent`, a project name alone, a one-word label, or specificity unsupported by evidence.
 

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -210,23 +210,31 @@ export function validateTabLabel(label: unknown): label is string {
   if (/[\r\n]/.test(String(label ?? ""))) return false;
   const value = sanitizeText(label);
   if (!value || value.length > MAX_TAB_LENGTH) return false;
+
+  if (/\p{Script=Han}/u.test(value)) {
+    if (value.length < 2) return false;
+    return /^[\p{Script=Han}A-Za-z0-9][\p{Script=Han}A-Za-z0-9\s+.#/'-_&·]*[\p{Script=Han}A-Za-z0-9+]$/u.test(
+      value,
+    );
+  }
+
   const words = value.split(/\s+/);
   if (words.length < 2 || words.length > 4) return false;
-  const connectors = new Set([
-    "a",
-    "an",
-    "and",
-    "for",
-    "in",
-    "of",
-    "on",
-    "to",
-    "with",
-  ]);
+  const connectors: Record<string, true> = {
+    a: true,
+    an: true,
+    and: true,
+    for: true,
+    in: true,
+    of: true,
+    on: true,
+    to: true,
+    with: true,
+  };
   return words.every(
     (word, index) =>
       /^[A-Z0-9][A-Za-z0-9+.#/'-]*$/.test(word) ||
-      (index > 0 && connectors.has(word)),
+      (index > 0 && connectors[word]),
   );
 }
 

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -49,6 +49,14 @@ test("label, workspace, and process policy stays deterministic", () => {
     ["One", false],
     ["This Label Has Far Too Many Words", false],
     ["Fix\nSocket", false],
+    ["修复认证问题", true],
+    ["同步主分支", true],
+    ["清理系统进程", true],
+    ["修复 MCP 故障", true],
+    ["构建 C++ 模块", true],
+    ["测试", true],
+    ["测", false],
+    ["这是一串超级超级长长长长长长长长长长长长长长长长长长长长长的标题", false],
   ] as const) {
     assert.equal(validateTabLabel(label), valid, label);
   }


### PR DESCRIPTION
### Summary

This PR adds support for CJK / Chinese tab labels in `validateTabLabel` and updates the naming policy so AI models can propose concise Chinese labels when user requests are in Chinese.

### Motivation

Previously, `validateTabLabel` strictly required labels to be split by whitespace into 2–4 Title Case English words (`/^[A-Z0-9][A-Za-z0-9+.#/'-]*$/`). In non-English contexts (such as Chinese), valid task names (e.g. `修复认证变更`, `同步主分支`, `清理系统进程`) were rejected and caused runtime errors (`invalid model tab label`), forcing tabs to fall back or fail.

### Changes

1. **`src/domain.ts`**:
   - Extended `validateTabLabel` to recognize Han characters (`\p{Script=Han}`).
   - Allows natural Chinese phrases (2–30 characters) as well as mixed Chinese and technical terms/acronyms (e.g. `修复 MCP 故障`, `构建 C++ 模块`).
   - Retained existing English word count and Title Case validation for backward compatibility.
2. **`docs/naming-policy.md`**:
   - Instructed models to match the primary language of user requests (concise Chinese for Chinese requests, Title Case words for English).
   - Provided good examples for both Chinese and English.
3. **`test/domain.test.ts`**:
   - Added unit test coverage for Chinese, mixed-language, single-character (reject), newline (reject), and length boundary checks.

### Verification

- `bun run check` (`tsc --noEmit`): Passed with 0 errors.
- `bun test`: All 114 tests passed.