### PR TITLE
refactor(provider): add extensible direct provider registry

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,9 @@ Selection reloads before each model-backed rename. If the selected source fails,
 
 Direct keeps working without `model-selection.json`. Existing `provider.env` settings are read before every request.
 
-Defaults come from [`provider.env.example`](../provider.env.example). Process settings override the private file, which overrides the defaults.
+The private file starts from [`provider.env.example`](../provider.env.example). Process settings override the private file, which overrides registered provider defaults.
+
+Known Direct providers are defined in a registry that can supply endpoint, model, reasoning, and key-variable defaults. OpenAI is the default profile. Providers not in the registry remain supported when their OpenAI-compatible endpoint, model, and key are configured explicitly.
 
 | Setting | Purpose |
 | --- | --- |

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -1,0 +1,44 @@
+export type ReasoningEffort = "low" | "medium" | "high";
+
+export interface DirectProviderProfile {
+  readonly id: string;
+  readonly label: string;
+  readonly defaultBaseURL?: string;
+  readonly defaultModel?: string;
+  readonly defaultReasoningEffort?: ReasoningEffort;
+  readonly apiKeyEnvNames: readonly string[];
+}
+
+export const DEFAULT_DIRECT_PROVIDER_ID = "openai";
+
+const DIRECT_PROVIDER_PROFILES: readonly DirectProviderProfile[] = [
+  {
+    id: DEFAULT_DIRECT_PROVIDER_ID,
+    label: "OpenAI",
+    defaultBaseURL: "https://api.openai.com/v1",
+    defaultModel: "gpt-5.6-luna",
+    defaultReasoningEffort: "medium",
+    apiKeyEnvNames: ["OPENAI_API_KEY"],
+  },
+  {
+    id: "kimi-code",
+    label: "Kimi Code",
+    apiKeyEnvNames: ["KIMI_API_KEY"],
+  },
+] as const;
+
+export function directProviderProfiles(): readonly DirectProviderProfile[] {
+  return DIRECT_PROVIDER_PROFILES;
+}
+
+export function directProviderProfile(
+  provider: string,
+): DirectProviderProfile | undefined {
+  return DIRECT_PROVIDER_PROFILES.find((profile) => profile.id === provider);
+}
+
+export function defaultDirectProviderProfile(): DirectProviderProfile {
+  const profile = directProviderProfile(DEFAULT_DIRECT_PROVIDER_ID);
+  if (!profile) throw new Error("Default direct provider is not registered");
+  return profile;
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -9,6 +9,10 @@ import {
   type NamingContext,
   validateTabLabel,
 } from "./domain.ts";
+import {
+  DEFAULT_DIRECT_PROVIDER_ID,
+  directProviderProfile,
+} from "./provider-registry.ts";
 import { sanitizeText } from "./text.ts";
 
 const PROVIDER_ENV_BYTES = 16 * 1024;
@@ -25,8 +29,12 @@ const ProviderConfigSchema = z.object({
   baseURL: z
     .url()
     .refine((value) => {
-      const url = new URL(value);
-      return ["http:", "https:"].includes(url.protocol) && !url.username && !url.password;
+      try {
+        const url = new URL(value);
+        return ["http:", "https:"].includes(url.protocol) && !url.username && !url.password;
+      } catch {
+        return false;
+      }
     })
     .transform((value) => value.replace(/\/$/, "")),
   model: z.string().min(1).refine((value) => !/[\r\n]/.test(value)),
@@ -119,16 +127,13 @@ function providerApiKey(
   processEnv: NodeJS.ProcessEnv,
   fileEnv: Record<string, string>,
 ): string {
-  const providerKey =
-    provider === "openai"
-      ? "OPENAI_API_KEY"
-      : provider === "kimi-code"
-        ? "KIMI_API_KEY"
-        : null;
+  const providerKeys = directProviderProfile(provider)?.apiKeyEnvNames ?? [];
   return (
     processEnv.SMART_RENAME_API_KEY ||
     fileEnv.SMART_RENAME_API_KEY ||
-    (providerKey ? processEnv[providerKey] || fileEnv[providerKey] : "") ||
+    providerKeys
+      .map((name) => processEnv[name] || fileEnv[name])
+      .find(Boolean) ||
     ""
   );
 }
@@ -177,20 +182,31 @@ export async function loadProviderConfig(
     readProviderEnv(PROVIDER_EXAMPLE_URL, true),
     readProviderEnv(providerEnvPath(env)),
   ]);
-  const provider = pick(env, fileEnv, defaults, "SMART_RENAME_PROVIDER");
+  const provider =
+    env.SMART_RENAME_PROVIDER ||
+    fileEnv.SMART_RENAME_PROVIDER ||
+    DEFAULT_DIRECT_PROVIDER_ID;
+  const profile = directProviderProfile(provider);
   const configuredReasoning =
     env.SMART_RENAME_REASONING_EFFORT ?? fileEnv.SMART_RENAME_REASONING_EFFORT;
   const reasoningEffort =
     configuredReasoning ??
-    (provider === defaults.SMART_RENAME_PROVIDER
-      ? defaults.SMART_RENAME_REASONING_EFFORT
-      : "");
+    profile?.defaultReasoningEffort ??
+    "";
   const configuredPrompt =
     env.SMART_RENAME_PROMPT_PATH || fileEnv.SMART_RENAME_PROMPT_PATH;
   const input = {
     provider,
-    baseURL: pick(env, fileEnv, defaults, "SMART_RENAME_BASE_URL"),
-    model: pick(env, fileEnv, defaults, "SMART_RENAME_MODEL"),
+    baseURL:
+      env.SMART_RENAME_BASE_URL ||
+      fileEnv.SMART_RENAME_BASE_URL ||
+      profile?.defaultBaseURL ||
+      "",
+    model:
+      env.SMART_RENAME_MODEL ||
+      fileEnv.SMART_RENAME_MODEL ||
+      profile?.defaultModel ||
+      "",
     timeoutMs: Number(pick(env, fileEnv, defaults, "SMART_RENAME_TIMEOUT_MS")),
     ...(reasoningEffort ? { reasoningEffort } : {}),
     ...(configuredPrompt

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -8,6 +8,10 @@ import {
 import { checkAi } from "./cli.ts";
 import { loadProviderConfig } from "./provider.ts";
 import {
+  defaultDirectProviderProfile,
+  directProviderProfile,
+} from "./provider-registry.ts";
+import {
   loadModelSelection,
   resolvePluginConfigDirectory,
   saveModelSelection,
@@ -257,15 +261,17 @@ async function collectChoice(
 }
 
 async function collectDirectConfig(prompts: SetupPrompts): Promise<DirectSetupConfig | undefined> {
-  const provider = await answer<string>(prompts, prompts.text({ message: "Provider", defaultValue: "openai" }));
+  const defaultProvider = defaultDirectProviderProfile();
+  const provider = await answer<string>(prompts, prompts.text({ message: "Provider", defaultValue: defaultProvider.id }));
   if (provider === undefined) return undefined;
-  const baseURL = await answer<string>(prompts, prompts.text({ message: "Base URL", defaultValue: "https://api.openai.com/v1" }));
+  const profile = directProviderProfile(provider);
+  const baseURL = await answer<string>(prompts, prompts.text({ message: "Base URL", ...(profile?.defaultBaseURL ? { defaultValue: profile.defaultBaseURL } : {}) }));
   if (baseURL === undefined) return undefined;
-  const model = await answer<string>(prompts, prompts.text({ message: "Model", defaultValue: "gpt-5.6-luna" }));
+  const model = await answer<string>(prompts, prompts.text({ message: "Model", ...(profile?.defaultModel ? { defaultValue: profile.defaultModel } : {}) }));
   if (model === undefined) return undefined;
   const apiKey = await answer<string>(prompts, prompts.password({ message: "API key" }));
   if (apiKey === undefined) return undefined;
-  const reasoning = await answer<string>(prompts, prompts.select({ message: "Reasoning level", initialValue: "medium", options: [{ value: "none", label: "None" }, { value: "low", label: "Low" }, { value: "medium", label: "Medium" }, { value: "high", label: "High" }] }));
+  const reasoning = await answer<string>(prompts, prompts.select({ message: "Reasoning level", initialValue: profile?.defaultReasoningEffort ?? "none", options: [{ value: "none", label: "None" }, { value: "low", label: "Low" }, { value: "medium", label: "Medium" }, { value: "high", label: "High" }] }));
   if (reasoning === undefined) return undefined;
   const timeout = await answer<string>(prompts, prompts.text({ message: "Timeout (ms)", defaultValue: "45000" }));
   if (!provider || !baseURL || !model || !apiKey || !reasoning || !timeout) return undefined;

--- a/test/provider-registry.test.ts
+++ b/test/provider-registry.test.ts
@@ -1,0 +1,30 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_DIRECT_PROVIDER_ID,
+  defaultDirectProviderProfile,
+  directProviderProfile,
+  directProviderProfiles,
+} from "../src/provider-registry.ts";
+
+test("OpenAI is the registered default direct provider", () => {
+  assert.equal(DEFAULT_DIRECT_PROVIDER_ID, "openai");
+  assert.deepEqual(defaultDirectProviderProfile(), {
+    id: "openai",
+    label: "OpenAI",
+    defaultBaseURL: "https://api.openai.com/v1",
+    defaultModel: "gpt-5.6-luna",
+    defaultReasoningEffort: "medium",
+    apiKeyEnvNames: ["OPENAI_API_KEY"],
+  });
+  assert.equal(directProviderProfiles()[0]?.id, DEFAULT_DIRECT_PROVIDER_ID);
+});
+
+test("direct provider profiles centralize key aliases and optional defaults", () => {
+  assert.deepEqual(directProviderProfile("kimi-code"), {
+    id: "kimi-code",
+    label: "Kimi Code",
+    apiKeyEnvNames: ["KIMI_API_KEY"],
+  });
+  assert.equal(directProviderProfile("custom-provider"), undefined);
+});

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -58,6 +58,14 @@ test("provider config preserves defaults and process-over-file precedence", asyn
       }),
       /AI key missing/,
     );
+    await assert.rejects(
+      loadProviderConfig({
+        ...fixture.env,
+        SMART_RENAME_PROVIDER: "custom-provider",
+        SMART_RENAME_API_KEY: "custom-key",
+      }),
+      /SMART_RENAME_BASE_URL/,
+    );
 
     await writeFile(
       fixture.file,

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -261,6 +261,29 @@ test("Direct wizard masks the API key and persists private connection mapping", 
     },
   );
   assert.equal(ui.calls.filter((call) => call.kind === "password").length, 1);
+  const textCalls = ui.calls.filter((call) => call.kind === "text");
+  assert.equal(
+    (textCalls[0]?.options as { defaultValue?: string }).defaultValue,
+    "openai",
+  );
+  assert.equal(
+    (textCalls[1]?.options as { defaultValue?: string }).defaultValue,
+    "https://api.openai.com/v1",
+  );
+  assert.equal(
+    (textCalls[2]?.options as { defaultValue?: string }).defaultValue,
+    "gpt-5.6-luna",
+  );
+  assert.equal(
+    (
+      ui.calls.find(
+        (call) =>
+          call.kind === "select" &&
+          (call.options as { message?: string }).message === "Reasoning level",
+      )?.options as { initialValue?: string }
+    ).initialValue,
+    "medium",
+  );
   assert.deepEqual(writes, [
     {
       kind: "direct",


### PR DESCRIPTION
## Summary

- centralize Direct provider defaults and key aliases in a typed registry
- declare OpenAI as the default provider and derive setup defaults from its profile
- preserve Kimi key alias support and explicit configuration for unregistered OpenAI-compatible vendors
- report a safe configuration error when a custom provider omits its endpoint

## Verification

- `bun run check`
- `bun test` (110 passed, 6 integration tests skipped)